### PR TITLE
update primary color

### DIFF
--- a/node_modules/bootstrap/scss/_variables.scss
+++ b/node_modules/bootstrap/scss/_variables.scss
@@ -62,7 +62,7 @@ $colors: map-merge((
   "gray-dark":  $gray-800
 ), $colors);
 
-$primary:       #de3636 !default;
+$primary:       #ac4142 !default;
 $secondary:     $gray-600 !default;
 $success:       $green !default;
 $info:          $cyan !default;


### PR DESCRIPTION
The primary color is now updated to what is used in select.html. For any files like select.html a class was added to the html file and in this case defined in the learn.scss file as #ac4142. This will no longer be needed. It will probably be a good idea to go on and make changes if the files are being worked on as #ac4142 is now the primary color in variables.scss and for any files currently being worked on make sure to use primary. 

