### PR TITLE
add ClassDB Access Privileges Back

### DIFF
--- a/server/controlPanel/instructorControlPanel.js
+++ b/server/controlPanel/instructorControlPanel.js
@@ -33,7 +33,7 @@ function addStudent(req, res) {
 				'FROM Attends AS A INNER JOIN Class AS C ON A.ClassID = C.ClassID ' +
 				'WHERE Username = $1 AND ClassName = $2', [req.user.username, req.body.classname])
 				.then((result) => {
-					var db = dbCreator(result);
+					var db = dbCreator(result.classid);
 					db.func('ClassDB.createStudent',
 						[req.body.username, req.body.fullname])
 					.then((result) => {
@@ -81,7 +81,7 @@ function dropStudent(req, res) {
 				'FROM Attends AS A INNER JOIN Class AS C ON A.ClassID = C.ClassID ' +
 				'WHERE Username = $1 AND ClassName = $2', [req.user.username, req.body.classname])
 				.then((result) => {
-					var db = dbCreator(result);
+					var db = dbCreator(result.classid);
 					db.func('ClassDB.dropStudent', [req.body.username, false,
 							true, 'drop'])
 					.then((result) => {
@@ -125,7 +125,7 @@ function getClass(req, res) {
 				'FROM Attends AS A INNER JOIN Class AS C ON A.ClassID = C.ClassID ' +
 				'WHERE Username = $1 AND ClassName = $2', [req.user.username, req.body.classname])
 				.then((result) => {
-					var db = dbCreator(result);
+					var db = dbCreator(result.classid);
 					db.any('SELECT * FROM ClassDB.StudentActivitySummary')
 					.then((result) => {
 						resolve();

--- a/server/db/cdb.js
+++ b/server/db/cdb.js
@@ -1,11 +1,25 @@
+/**
+ * cdb.js - LearnSQL
+ *
+ * Kevin Kelly
+ * Web Applications and Databases for Education (WADE)
+ *
+ * This file contains the functions for dynamically creating connections to
+ *  ClassDB databases
+ */
+
 // Loading and initializing the library:
 const pgp = require('pg-promise')({
     // Initialization Options
 });
 
-// Exporting the database object for shared use:
+/*
+ * Exporting the database object for shared use
+ *
+ * @param {string} query the name of the database
+ */
 module.exports = function (query) {
 	const connectionString = 'postgresql://postgres:password@localhost:5432/'
-							 + query.classid;
+							 + query;
 	return db = pgp(connectionString);
 };


### PR DESCRIPTION
This PR adds the access privileges back to a ClassDB database upon creation. This used the already present `reAddUserAccess()` function in the ClassDB template.

I also cleaned `createClass(req, res)` to use a task for all LearnSQL database queries.

This can be tested in `http://localhost:3000/views/test.html`

fixes #49 