### PR TITLE
Make classname/section check not case sensitive

### DIFF
--- a/src/db/LearnSQL/classMgmt.sql
+++ b/src/db/LearnSQL/classMgmt.sql
@@ -84,8 +84,8 @@ BEGIN
               FROM LearnSQL.Class_t INNER JOIN LearnSQL.Attends
               ON Attends.classID = Class_t.classID
               WHERE Attends.userName = $3
-              AND Class_t.className = $5
-              AND Class_t.section = $6
+              AND Class_t.className = LOWER($5)
+              AND Class_t.section = LOWER($6)
             ) 
   THEN 
     RAISE EXCEPTION 'Section And Class Name Already Exists!';


### PR DESCRIPTION
This PR makes it so that teachers cannot make classes with the same name or section but with varying cases. Classname `CS305` Section `71` and Classname `cs305` Section `71` were recognized as different classes but should be recognized as one class and the application should not allow the creation of the second instance of that. To fix this issue I added `LOWER` to the checks. 




Fixes #102 